### PR TITLE
Partial Fix for 1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ output/PrepareLanding/1.3/Assemblies/*.mdb
 output/PrepareLanding/1.4/Assemblies/*.dll
 output/PrepareLanding/1.4/Assemblies/*.pdb
 output/PrepareLanding/1.4/Assemblies/*.mdb
+output/PrepareLanding/1.5/Assemblies/*.dll
+output/PrepareLanding/1.5/Assemblies/*.pdb
+output/PrepareLanding/1.5/Assemblies/*.mdb
 
 # Ignore specific tools (pdb2mdb)
 

--- a/PrepareLanding.csproj
+++ b/PrepareLanding.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>output\PrepareLanding\1.4\Assemblies\</OutputPath>
+    <OutputPath>output\PrepareLanding\1.5\Assemblies\</OutputPath>
     <DefineConstants>TRACE;WORLD_DATA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -34,11 +34,11 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>packages\Lib.Harmony.2.2.2\lib\net472\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.3.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Lib.Harmony.2.3.3\lib\net472\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="HugsLib">
-      <HintPath>packages\UnlimitedHugs.Rimworld.HugsLib.10.0.1\lib\net472\HugsLib.dll</HintPath>
+    <Reference Include="HugsLib, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnlimitedHugs.Rimworld.HugsLib.11.0.3\lib\net472\HugsLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -46,31 +46,31 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="Assembly-CSharp">
-      <HintPath>libs\1.4\Assembly-CSharp.dll</HintPath>
+      <HintPath>libs\1.5\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>libs\1.4\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>libs\1.5\Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>libs\1.4\UnityEngine.dll</HintPath>
+      <HintPath>libs\1.5\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>libs\1.4\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>libs\1.5\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>libs\1.4\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>libs\1.5\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>libs\1.4\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>libs\1.5\UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>libs\1.4\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>libs\1.5\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -157,7 +157,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>if $(ConfigurationName) == Debug python $(ProjectDir)tools\pdb2mdb.py $(TargetPath)
-if $(ConfigurationName) == Debug python $(ProjectDir)tools\copy_to_rimworld.py $(TargetDir) K:\rimworld_debug\RimWorld_14 1.4 --output_dir $(ProjectDir)output\$(TargetName) --pdb --mdb</PostBuildEvent>
+if $(ConfigurationName) == Debug python $(ProjectDir)tools\copy_to_rimworld.py $(TargetDir) D:\Steam\steamapps\common\RimWorld 1.5 --output_dir $(ProjectDir)output\$(TargetName) --pdb --mdb</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("PrepareLanding")]
-[assembly: AssemblyDescription("A RimWorld 1.4 mod")]
+[assembly: AssemblyDescription("A RimWorld 1.5 mod")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("neitsa")]
 [assembly: AssemblyProduct("PrepareLanding")]
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]

--- a/output/PrepareLanding/About/About.xml
+++ b/output/PrepareLanding/About/About.xml
@@ -8,13 +8,14 @@
       <li>1.1</li>
       <li>1.2</li>      
       <li>1.3</li>
-      <li>1.4</li>            
+      <li>1.4</li>  
+	  <li>1.5</li>
     </supportedVersions>
    <packageId>neitsa.PrepareLanding</packageId>
 	<description>Prepare your landing by picking the right tile on the world map!
 You can also change tile characteristics to your liking.
 
-[Version 1.4.0]
+[Version 1.5.0]
 	</description>
 	<modDependencies>
       <li>

--- a/output/PrepareLanding/About/Manifest.xml
+++ b/output/PrepareLanding/About/Manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Manifest>
     <identifier>PrepareLanding</identifier>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <manifestUri>https://raw.githubusercontent.com/neitsa/PrepareLanding/develop/output/PrepareLanding/About/Manifest.xml</manifestUri>
     <downloadUri>https://github.com/neitsa/PrepareLanding/releases/latest</downloadUri>
 </Manifest>

--- a/output/PrepareLanding/About/Version.xml
+++ b/output/PrepareLanding/About/Version.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <VersionData>
-	<overrideVersion>1.4.0</overrideVersion>
+	<overrideVersion>1.5.0</overrideVersion>
 	<gitHubRepository>neitsa/PrepareLanding</gitHubRepository>
 </VersionData>

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Lib.Harmony" version="2.2.2" targetFramework="net472" />
-  <package id="UnlimitedHugs.Rimworld.HugsLib" version="10.0.1" targetFramework="net472" />
+  <package id="Lib.Harmony" version="2.3.3" targetFramework="net472" />
+  <package id="UnlimitedHugs.Rimworld.HugsLib" version="11.0.3" targetFramework="net472" />
 </packages>

--- a/src/TabLoadSave.cs
+++ b/src/TabLoadSave.cs
@@ -457,7 +457,7 @@ namespace PrepareLanding
 
             ListingStandard.Label("PLMWLODSAV_PresetDescription".Translate());
             var descriptionRect = ListingStandard.GetRect(80f);
-            Widgets.TextAreaScrollable(descriptionRect, preset.PresetInfo.Description,
+            LudeonTK.DevGUI.TextAreaScrollable(descriptionRect, preset.PresetInfo.Description,
                 ref _scrollPosPresetLoadDescription);
 
             ListingStandard.Label("PLMWLODSAV_PresetFilters".Translate());
@@ -537,7 +537,7 @@ namespace PrepareLanding
             DrawEntryHeader(string.Format("PLMWLODSAV_DescriptionString".Translate(), MaxDescriptionLength));
 
             var descriptionRect = ListingStandard.GetRect(80f);
-            _presetDescriptionSave = Widgets.TextAreaScrollable(descriptionRect, _presetDescriptionSave,
+            _presetDescriptionSave = LudeonTK.DevGUI.TextAreaScrollable(descriptionRect, _presetDescriptionSave,
                 ref _scrollPosPresetDescription);
             if (_presetDescriptionSave.Length >= MaxDescriptionLength)
                 _presetDescriptionSave = _presetDescriptionSave.Substring(0, MaxDescriptionLength);


### PR DESCRIPTION
The **Widgets.TextAreaScrollable** method got moved to **LudeonTK.DevGUI**.

Fixing the reference makes the tile highlighting works, but the scrollable of selected items is blank. I made do without it.

The method itself doesn't seem to have significantly changed beyond the readOnly interpretation.

This was my first time modding with RimWorld, so hopefully I didn't butcher any of the non-code files.